### PR TITLE
Fix credentials leak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.7-slim
 ARG PIP_EXTRA_URL
 
 COPY requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt --extra-index-url $PIP_EXTRA_URL
+
+RUN --mount=type=secret,id=PIP_EXTRA_URL \
+    pip install -r /tmp/requirements.txt --extra-index-url $(cat /run/secrets/PIP_EXTRA_URL)
 
 RUN mkdir /app
 COPY . /app

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,9 +39,13 @@ stages:
         command: build
         repository: $(imageRepository)
         containerRegistry: $(dockerRegistryServiceConnection)
-        arguments: --build-arg PIP_EXTRA_URL="$(artifactoryUrl)"
+        # --secret securely mounts env variable PIP_EXTRA_URL that possibly contains sensitive credentials to /run/secrets/PIP_EXTRA_URL during docker build
+        arguments: --secret id=PIP_EXTRA_URL
         tags: |
           $(tag)
+      env:
+        PIP_EXTRA_URL: $(artifactoryUrl)
+        DOCKER_BUILDKIT: 1  # required to pass secrets to docker build
 
     - task: Docker@2
       displayName: Push the image to container registry


### PR DESCRIPTION
When PIP_EXTRA_URL is passed as a build argument, it's forever embedded into the docker image. 

Using secrets avoids this.